### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,8 +14,8 @@ If you are __upgrading your existing cart__, be sure to read the [upgrade instru
 3. Rename config-dist.php to config.php and admin/config-dist.php to admin/config.php
 4. For Linux/Unix make sure the following folders and files are writable.
 
-		chmod 0777 config.php
-		chmod 0777 admin/config.php
+		chmod 0600 config.php
+		chmod 0600 admin/config.php
 
 5. Make sure you have installed a MySQL Database which has a user assigned to it
 	* do not use your `root` username and root password


### PR DESCRIPTION
fix loose permissions (weak security posture) on config.php and admin/config.php  If webserver uses say www-data for the group, many other people (anyone in the www-data group) could have read/write/execute  Anyone with access to the system, and the directories, can modify config.php.  Do not allow this.  Remove 4th 7 and replace with 0. Execute permission means nothing on a php file by itself, however if modified by a user with access to it, they can make it do bad things.  Drop execute permissions for everyone.